### PR TITLE
Add a PermissionValidationService component to atlassian-plugins.xml

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -116,6 +116,7 @@
     However they depend upon PermissionService which is not included automatically as a transitive dependency, so we need this:
     -->
     <component-import key="permissionService" interface="com.atlassian.stash.user.PermissionService"/>
+    <component-import key="permissionValidationService" interface="com.atlassian.stash.user.PermissionValidationService"/>
 
     <component key="commandOutputHandlerFactory" class="com.palantir.stash.stashbot.outputhandler.CommandOutputHandlerFactory" />
     <component key="configurationPersistenceManager" class="com.palantir.stash.stashbot.config.ConfigurationPersistenceManager" />


### PR DESCRIPTION
Apparently, the packaged jar will fail unless PermissionValidationService is imported in atlassian-plugins (even if it succeeds on a atlas-run dev instance).
