### PR TITLE
Bugfix: get mergeRefUrl from source repository, not destination one

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/managers/JenkinsManager.java
+++ b/src/main/java/com/palantir/stash/stashbot/managers/JenkinsManager.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 
 import com.atlassian.stash.hook.repository.RepositoryHookService;
 import com.atlassian.stash.pull.PullRequest;
+import com.atlassian.stash.pull.PullRequestRef;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.repository.RepositoryService;
 import com.atlassian.stash.util.Page;
@@ -260,9 +261,16 @@ public class JenkinsManager {
                 builder.put("buildHead", pullRequest.getToRef()
                     .getLatestChangeset().toString());
                 // fromRef may be in a different repo
-                builder.put("mergeRef", pullRequest.getFromRef().getDisplayId());
-                builder.put("mergeRefUrl", sub.buildCloneUrl(repo, jsc));
-                builder.put("mergeHead", pullRequest.getFromRef()
+                PullRequestRef fromRef = pullRequest.getFromRef();
+                builder.put("mergeRef", fromRef.getDisplayId());
+                Repository fromRepo = fromRef.getRepository();
+                if( rc.getUseSsh().booleanValue() ) {
+                    builder.put("mergeRefUrl", sshCloneUrlResolver.getCloneUrl(fromRepo));
+                }
+                else {
+                    builder.put("mergeRefUrl", sub.buildCloneUrl(fromRepo, jsc));
+                }
+                builder.put("mergeHead", fromRef
                     .getLatestChangeset().toString());
             }
 


### PR DESCRIPTION
Stashbot is currently unable to merge pull requests from a separate fork because the URL used to synthesize the mergeRefUrl parameter is the one belonging to the destination fork (which admittedly is the same as the source one in most cases).

Please note that this patch can be applied cleanly only after pull request #6 (Feature/ssh), otherwise the checking of the "useSsh" flag (lines 267-270, 272) will cause compilation errors.