### PR TITLE
Shortened SHA1 digests in Stash comments.

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/admin/BuildSuccessReportingServlet.java
+++ b/src/main/java/com/palantir/stash/stashbot/admin/BuildSuccessReportingServlet.java
@@ -184,8 +184,8 @@ public class BuildSuccessReportingServlet extends HttpServlet {
             final StringBuffer sb = new StringBuffer();
             final String url = getJenkinsUrl(repo, jt, buildNumber);
 
-            String mergeHead1 = (mergeHead != null)? mergeHead.substring(0, 8) : null;
-            String buildHead1 = (buildHead != null)? buildHead.substring(0, 8) : null;
+            String mergeHead1 = (mergeHead != null)? mergeHead.substring(0, 12) : null;
+            String buildHead1 = (buildHead != null)? buildHead.substring(0, 12) : null;
 
             /* NOTE: mergeHead and buildHead are the reverse of what you might
              * think, because we have to check out the "toRef" becasue it is


### PR DESCRIPTION
Soon after we introduced Stashbot at our company, developers started complaining at the "cryptic" comments the bot was adding to their PRs. After a few conversations it turned out that the length of the SHA1 digests in the message is a cognitive barrier for surprisingly many people, experienced developers included -- some of them weren't even aware of the links at the end of the message (!) After applying this patch to reduce the digests in comments to 8 characters, all complains vanished :-)
