### PR TITLE
Make 'Trigger PR' conditional

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -100,6 +100,7 @@
     <web-resource key="pullRequestTriggerResources" name="Pull Request Trigger Link Resources">
         <dependency>com.atlassian.auiplugin:ajs</dependency>
         <dependency>stash.web.resources:jquery</dependency>
+        <condition class="com.palantir.stash.stashbot.webpanel.IsCiEnabledForRepoCondition"/>
         <resource type="download" name="pr-trigger.js" location="js/pr-trigger.js"/>
         <context>stash.page.pullRequest.view</context>
     </web-resource>


### PR DESCRIPTION
If the repo does not have CI enabled the link can be confusing so adding a condition to only show it when CI is enabled