### PR TITLE
Tag resetting after git checkout

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/jobtemplate/JenkinsJobXmlFormatter.java
+++ b/src/main/java/com/palantir/stash/stashbot/jobtemplate/JenkinsJobXmlFormatter.java
@@ -68,7 +68,7 @@ public class JenkinsJobXmlFormatter {
         final JenkinsServerConfiguration jsc = cpm
             .getJenkinsServerConfiguration(rc.getJenkinsServerName());
         StringBuffer sb = new StringBuffer();
-        sb.append("/usr/bin/curl -s -i ");
+        sb.append("/usr/bin/curl -k -s -i ");
         sb.append(sub.buildReportingUrl(repo, jobTemplate.getJobType(), jsc, status));
         return sb.toString();
     }

--- a/src/main/resources/jenkins-publish-job.vm
+++ b/src/main/resources/jenkins-publish-job.vm
@@ -101,7 +101,7 @@
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
         <command>
-git tag | xargs git tag -d
+git for-each-ref --format='delete %(refname)' refs/tags | git update-ref --stdin
 git fetch --tags
 (git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)
         </command>

--- a/src/main/resources/jenkins-publish-job.vm
+++ b/src/main/resources/jenkins-publish-job.vm
@@ -100,7 +100,11 @@
   <builders>
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
-        <command>(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)</command>
+        <command>
+git tag | xargs git tag -d
+git fetch --tags
+(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)
+        </command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
         <command>$esc.xml($startedCommand)</command>

--- a/src/main/resources/jenkins-verify-job.vm
+++ b/src/main/resources/jenkins-verify-job.vm
@@ -99,7 +99,7 @@
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
         <command>
-git tag | xargs git tag -d
+git for-each-ref --format='delete %(refname)' refs/tags | git update-ref --stdin
 git fetch --tags
 (git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)
         </command>

--- a/src/main/resources/jenkins-verify-job.vm
+++ b/src/main/resources/jenkins-verify-job.vm
@@ -98,7 +98,11 @@
   <builders>
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
-        <command>(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)</command>
+        <command>
+git tag | xargs git tag -d
+git fetch --tags
+(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)
+        </command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
         <command>$esc.xml($startedCommand)</command>

--- a/src/main/resources/jenkins-verify-pull-request-job.vm
+++ b/src/main/resources/jenkins-verify-pull-request-job.vm
@@ -121,7 +121,11 @@
   <builders>
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
-        <command>(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)</command>
+        <command>
+git tag | xargs git tag -d
+git fetch --tags
+(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)
+        </command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
         <command>$esc.xml($startedCommand)</command>

--- a/src/main/resources/jenkins-verify-pull-request-job.vm
+++ b/src/main/resources/jenkins-verify-pull-request-job.vm
@@ -122,7 +122,7 @@
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
         <command>
-git tag | xargs git tag -d
+git for-each-ref --format='delete %(refname)' refs/tags | git update-ref --stdin
 git fetch --tags
 (git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)
         </command>

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -13,6 +13,7 @@ Vagrant.configure(2) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 7990, host: 7990
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -33,6 +34,11 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 1024 * 4
     vb.cpus = 4
+  end
+
+  config.vm.provider "vmware_fusion" do |v|
+    v.vmx["memsize"] = 1024 * 8
+    v.vmx["numvcpus"] = 4
   end
 
   config.vm.provision :shell do |s|

--- a/vagrant/install-jenkins.sh
+++ b/vagrant/install-jenkins.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Install jenkins along with a bunch of plugins
+if [[ ! -e /var/lib/jenkins ]]; then
+  useradd -d /var/lib/jenkins jenkins
+  echo "jenkins ALL= NOPASSWD: ALL" >> /etc/sudoers
+  echo "Grabbing jenkins.war"
+  if [[ ! -e jenkins.war ]]; then
+    wget -q https://updates.jenkins-ci.org/latest/jenkins.war
+  fi
+  mkdir -p /var/lib/jenkins/jobs
+  mkdir -p /var/lib/jenkins/plugins
+  mkdir -p /var/lib/jenkins/users
+  # Copy any premade jobs (if there are any)
+  find ${path}jenkins/jobs -maxdepth 1 -mindepth 1 -type d | xargs -I% cp -r "%" /var/lib/jenkins/jobs
+  find ${path}jenkins/users -maxdepth 1 -mindepth 1 -type d | xargs -I% cp -r "%" /var/lib/jenkins/users
+  # Make sure we have various plugins
+  pushd /var/lib/jenkins/plugins
+  echo "Grabbing plugins"
+  wget -q http://updates.jenkins-ci.org/latest/git.hpi
+  wget -q http://updates.jenkins-ci.org/latest/scm-api.hpi
+  wget -q http://updates.jenkins-ci.org/latest/credentials.hpi
+  wget -q http://updates.jenkins-ci.org/latest/git-client.hpi
+  wget -q http://updates.jenkins-ci.org/latest/ssh-credentials.hpi
+  wget -q http://updates.jenkins-ci.org/latest/postbuild-task.hpi
+  popd
+  # Shell configuration for running bash and security configuration
+  echo "Copying configuration and starting jenkins"
+  cp ${path}jenkins/*.xml /var/lib/jenkins
+  chown -R jenkins:jenkins /var/lib/jenkins
+  export JENKINS_HOME=/var/lib/jenkins
+  nohup java -jar jenkins.war &
+fi
+if [[ ! $(ps aux | grep jenkins | grep -v grep | grep -v install) ]]; then
+  export JENKINS_HOME=/var/lib/jenkins
+  nohup java -jar jenkins.war 1> jenkins-server.out 2>&1 &
+fi

--- a/vagrant/jenkins/config.xml
+++ b/vagrant/jenkins/config.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.0</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>false</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/vagrant/jenkins/hudson.tasks.Shell.xml
+++ b/vagrant/jenkins/hudson.tasks.Shell.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson.tasks.Shell_-DescriptorImpl>
+  <shell>/bin/bash</shell>
+</hudson.tasks.Shell_-DescriptorImpl>

--- a/vagrant/jenkins/users/stash/config.xml
+++ b/vagrant/jenkins/users/stash/config.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>stash</fullName>
+  <properties>
+    <hudson.model.PaneStatusProperties>
+      <collapsed/>
+    </hudson.model.PaneStatusProperties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>iOK9eZD8E2TPuUWQckabykKemezMunAwn70SUBuLo0Os3FswSl8gh5pPruty/FLB</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty plugin="credentials@1.18">
+      <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash"/>
+    </com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>false</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>#jbcrypt:$2a$10$QEDPgy/781KJV9cZWFgUmOQb8rXfZrq.qxqsbUp0nZJb0lvGBrkvG</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+    <hudson.tasks.Mailer_-UserProperty plugin="mailer@1.11">
+      <emailAddress>stash@localhost</emailAddress>
+    </hudson.tasks.Mailer_-UserProperty>
+  </properties>
+</user>

--- a/vagrant/provisioner.sh
+++ b/vagrant/provisioner.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+export path="/vagrant/"
+
 yum -y install epel-release
-yum -y install java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel
+yum -y install git java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel
 
 pushd /etc/yum.repos.d/
 wget http://sdkrepo.atlassian.com/atlassian-sdk-stable.repo
@@ -8,3 +10,5 @@ yum clean all
 yum updateinfo metadata
 yum -y install atlassian-plugin-sdk
 popd
+
+${path}install-jenkins.sh


### PR DESCRIPTION
We keep running into the problem of people moving tags around and then having to manually fix broken repositories in Jenkins workspaces. So in addition to cleaning up the workspace we now clean up the tags as well and sync them up with what is available on the remote origin.

Added `-k` to reporting commands because it helps with self-signed certificates.

Improved the Vagrant dev environment by installing and starting Jenkins during provisioning.