### PR TITLE
Fix update to stash 3.11

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/config/ConfigurationPersistenceImpl.java
+++ b/src/main/java/com/palantir/stash/stashbot/config/ConfigurationPersistenceImpl.java
@@ -450,8 +450,8 @@ public class ConfigurationPersistenceImpl implements ConfigurationPersistenceSer
 
     private String pullRequestToString(PullRequest pr) {
         return "[id:" + Long.toString(pr.getId()) + ", from:"
-            + pr.getFromRef().getLatestChangeset() + ", to:"
-            + pr.getToRef().getLatestChangeset() + "]";
+            + pr.getFromRef().getLatestCommit() + ", to:"
+            + pr.getToRef().getLatestCommit() + "]";
     }
 
     /* (non-Javadoc)
@@ -460,8 +460,8 @@ public class ConfigurationPersistenceImpl implements ConfigurationPersistenceSer
     @Override
     public PullRequestMetadata getPullRequestMetadata(PullRequest pr) {
         return getPullRequestMetadata(pr.getToRef().getRepository().getId(), pr.getId(),
-            pr.getFromRef().getLatestChangeset().toString(),
-            pr.getToRef().getLatestChangeset().toString());
+            pr.getFromRef().getLatestCommit().toString(),
+            pr.getToRef().getLatestCommit().toString());
     }
 
     /* (non-Javadoc)
@@ -497,8 +497,8 @@ public class ConfigurationPersistenceImpl implements ConfigurationPersistenceSer
     @Override
     public ImmutableList<PullRequestMetadata> getPullRequestMetadataWithoutToRef(PullRequest pr) {
         Long id = pr.getId();
-        String fromSha = pr.getFromRef().getLatestChangeset().toString();
-        String toSha = pr.getToRef().getLatestChangeset().toString();
+        String fromSha = pr.getFromRef().getLatestCommit().toString();
+        String toSha = pr.getToRef().getLatestCommit().toString();
 
         PullRequestMetadata[] prms = ao.find(PullRequestMetadata.class,
             "PULL_REQUEST_ID = ? and FROM_SHA = ?", id, fromSha);
@@ -526,8 +526,8 @@ public class ConfigurationPersistenceImpl implements ConfigurationPersistenceSer
     @Override
     public void setPullRequestMetadata(PullRequest pr, Boolean buildStarted,
         Boolean success, Boolean override) {
-        setPullRequestMetadata(pr, pr.getFromRef().getLatestChangeset(),
-            pr.getToRef().getLatestChangeset(), buildStarted, success, override);
+        setPullRequestMetadata(pr, pr.getFromRef().getLatestCommit(),
+            pr.getToRef().getLatestCommit(), buildStarted, success, override);
     }
 
     // Allows fromHash and toHash to be set by the caller, in case we are referring to older commits

--- a/src/main/java/com/palantir/stash/stashbot/hooks/PullRequestBuildSuccessMergeCheck.java
+++ b/src/main/java/com/palantir/stash/stashbot/hooks/PullRequestBuildSuccessMergeCheck.java
@@ -23,8 +23,8 @@ import org.slf4j.Logger;
 import com.atlassian.stash.build.BuildStats;
 import com.atlassian.stash.build.BuildStatusService;
 import com.atlassian.stash.commit.CommitService;
-import com.atlassian.stash.content.Changeset;
-import com.atlassian.stash.content.ChangesetsBetweenRequest;
+import com.atlassian.stash.commit.Commit;
+import com.atlassian.stash.commit.CommitsBetweenRequest;
 import com.atlassian.stash.pull.PullRequest;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.scm.pull.MergeRequest;
@@ -113,11 +113,11 @@ public class PullRequestBuildSuccessMergeCheck implements MergeRequestCheck {
 
         // First, if strict mode is on, we want to veto for each commit in the PR that is missing a successful verify build
         if (rc.getStrictVerifyMode()) {
-            ChangesetsBetweenRequest cbr = new ChangesetsBetweenRequest.Builder(pr).build();
+            CommitsBetweenRequest cbr = new CommitsBetweenRequest.Builder(pr).build();
             PageRequest pageReq = new PageRequestImpl(0, 500);
-            Page<? extends Changeset> page = cs.getChangesetsBetween(cbr, pageReq);
+            Page<? extends Commit> page = cs.getCommitsBetween(cbr, pageReq);
             while (true) {
-                for (Changeset c : page.getValues()) {
+                for (Commit c : page.getValues()) {
                     log.trace("Processing commit " + c.getId());
                     BuildStats bs = bss.getStats(c.getId());
                     if (bs.getSuccessfulCount() == 0) {
@@ -130,7 +130,7 @@ public class PullRequestBuildSuccessMergeCheck implements MergeRequestCheck {
                     break;
                 }
                 pageReq = page.getNextPageRequest();
-                page = cs.getChangesetsBetween(cbr, pageReq);
+                page = cs.getCommitsBetween(cbr, pageReq);
             }
         }
 
@@ -139,7 +139,7 @@ public class PullRequestBuildSuccessMergeCheck implements MergeRequestCheck {
             // we want a PRM which simply matches the fromSha and the pull request ID.
             Collection<PullRequestMetadata> prms = cpm.getPullRequestMetadataWithoutToRef(pr);
             for (PullRequestMetadata cur : prms) {
-                if (cur.getFromSha().equals(pr.getFromRef().getLatestChangeset())
+                if (cur.getFromSha().equals(pr.getFromRef().getLatestCommit())
                     && (cur.getOverride() || cur.getSuccess())) {
                     log.debug("Found match PRM");
                     log.debug("PRM: success " + cur.getSuccess().toString() + " override "

--- a/src/main/java/com/palantir/stash/stashbot/hooks/PullRequestListener.java
+++ b/src/main/java/com/palantir/stash/stashbot/hooks/PullRequestListener.java
@@ -104,7 +104,7 @@ public class PullRequestListener {
                 return;
             }
             // just trigger a build of the new commit since the other hook doesn't catch merged PRs.
-            String mergeSha1 = event.getChangeset().getId();
+            String mergeSha1 = event.getCommit().getId();
             String targetBranch = pr.getToRef().getId();
             boolean publishEnabled = cpm.getJobTypeStatusMapping(rc, JobType.PUBLISH);
             boolean verifyEnabled = cpm.getJobTypeStatusMapping(rc, JobType.VERIFY_COMMIT);
@@ -175,7 +175,7 @@ public class PullRequestListener {
                         // build not started, so don't consider this PRM
                         continue;
                     }
-                    if (cur.getFromSha().equals(pr.getFromRef().getLatestChangeset())) {
+                    if (cur.getFromSha().equals(pr.getFromRef().getLatestCommit())) {
                         // we found a PRM for which buildstarted = true and fromSha matches, so return
                         return;
                     }

--- a/src/main/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHook.java
+++ b/src/main/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHook.java
@@ -185,10 +185,10 @@ public class TriggerJenkinsBuildHook implements PostReceiveHook {
 
         // returns in old-to-new order, already limited by max-verify-build limiter
         @SuppressWarnings("unchecked")
-        ImmutableList<String> changesets = (ImmutableList<String>) rloh.getOutput();
+        ImmutableList<String> commits = (ImmutableList<String>) rloh.getOutput();
 
         // For each new commit
-        for (String cs : changesets) {
+        for (String cs : commits) {
 
             if (publishBuilds.contains(cs)) {
                 log.info("Stashbot Trigger: NOT triggering VERIFICATION build for commit " + cs

--- a/src/main/java/com/palantir/stash/stashbot/managers/JenkinsManager.java
+++ b/src/main/java/com/palantir/stash/stashbot/managers/JenkinsManager.java
@@ -292,7 +292,7 @@ public class JenkinsManager implements DisposableBean {
 
         try {
             String pullRequestId = pullRequest.getId().toString();
-            String hashToBuild = pullRequest.getToRef().getLatestChangeset();
+            String hashToBuild = pullRequest.getToRef().getLatestCommit();
 
             RepositoryConfiguration rc = cpm
                 .getRepositoryConfigurationForRepository(repo);
@@ -325,13 +325,13 @@ public class JenkinsManager implements DisposableBean {
                 builder.put("pullRequestId", pullRequestId);
                 // toRef is always present in the repo
                 builder.put("buildHead", pullRequest.getToRef()
-                    .getLatestChangeset().toString());
+                    .getLatestCommit().toString());
                 // fromRef may be in a different repo
                 builder.put("mergeRef", pullRequest.getFromRef().getId());
                 builder.put("buildRef", pullRequest.getToRef().getId());
                 builder.put("mergeRefUrl", sub.buildCloneUrl(pullRequest.getFromRef().getRepository(), jsc));
                 builder.put("mergeHead", pullRequest.getFromRef()
-                    .getLatestChangeset().toString());
+                    .getLatestCommit().toString());
             }
 
             jobMap.get(key).build(builder.build());

--- a/src/main/java/com/palantir/stash/stashbot/outputhandler/CommandOutputHandlerFactory.java
+++ b/src/main/java/com/palantir/stash/stashbot/outputhandler/CommandOutputHandlerFactory.java
@@ -29,7 +29,7 @@ public class CommandOutputHandlerFactory {
     public CommandOutputHandler<Object> getRevlistOutputHandler() {
         return new CommandOutputHandler<Object>() {
 
-            private ArrayList<String> changesets;
+            private ArrayList<String> commits;
             private LineReader lr;
             private boolean processed = false;
 
@@ -46,14 +46,14 @@ public class CommandOutputHandlerFactory {
                 if (processed == false) {
                     throw new IllegalStateException("getOutput() called before process()");
                 }
-                return ImmutableList.copyOf(changesets).reverse();
+                return ImmutableList.copyOf(commits).reverse();
             }
 
             @Override
             public void process(InputStream output) throws ProcessException {
                 processed = true;
-                if (changesets == null) {
-                    changesets = new ArrayList<String>();
+                if (commits == null) {
+                    commits = new ArrayList<String>();
                     lr = new LineReader(new InputStreamReader(output));
                 }
 
@@ -66,7 +66,7 @@ public class CommandOutputHandlerFactory {
                         throw new RuntimeException(e);
                     }
                     if (sha1 != null && sha1.matches("[0-9a-fA-F]{40}")) {
-                        changesets.add(sha1);
+                        commits.add(sha1);
                     }
                 }
             }

--- a/src/main/java/com/palantir/stash/stashbot/servlet/BuildStatusReportingServlet.java
+++ b/src/main/java/com/palantir/stash/stashbot/servlet/BuildStatusReportingServlet.java
@@ -144,7 +144,7 @@ public class BuildStatusReportingServlet extends HttpServlet {
             output.put("canMerge", canMerge.canMerge());
             if (!canMerge.canMerge()) {
                 JSONArray vetoes = new JSONArray();
-                for (PullRequestMergeVeto prmv : canMerge.getVetos()) {
+                for (PullRequestMergeVeto prmv : canMerge.getVetoes()) {
                     JSONObject prmvjs = new JSONObject();
                     prmvjs.put("summary", prmv.getSummaryMessage());
                     prmvjs.put("details", prmv.getDetailedMessage());

--- a/src/main/java/com/palantir/stash/stashbot/urlbuilder/StashbotUrlBuilder.java
+++ b/src/main/java/com/palantir/stash/stashbot/urlbuilder/StashbotUrlBuilder.java
@@ -44,7 +44,7 @@ public class StashbotUrlBuilder {
         urlB.append(buildHead);
         if (pullRequest != null) {
             urlB.append("/");
-            urlB.append(pullRequest.getToRef().getLatestChangeset());
+            urlB.append(pullRequest.getToRef().getLatestCommit());
             urlB.append("/");
             urlB.append(pullRequest.getId().toString());
         }
@@ -87,8 +87,8 @@ public class StashbotUrlBuilder {
         return url;
     }
 
-    public String buildStashCommitUrl(Repository repo, String changeset) {
-        return nb.repo(repo).changeset(changeset).buildAbsolute();
+    public String buildStashCommitUrl(Repository repo, String commit) {
+        return nb.repo(repo).commit(commit).buildAbsolute();
     }
 
     private String mask( String str ) {

--- a/src/main/java/com/palantir/stash/stashbot/webpanel/IsCiEnabledForRepoCondition.java
+++ b/src/main/java/com/palantir/stash/stashbot/webpanel/IsCiEnabledForRepoCondition.java
@@ -42,7 +42,7 @@ public class IsCiEnabledForRepoCondition implements Condition {
     @Override
     public boolean shouldDisplay(Map<String, Object> context) {
 
-        // request, principal, changeset, repository
+        // request, principal, commit, repository
         Repository repo = (Repository) context.get("repository");
         RepositoryConfiguration rc;
         if (repo == null) {

--- a/src/main/java/com/palantir/stash/stashbot/webpanel/RetriggerLinkWebPanel.java
+++ b/src/main/java/com/palantir/stash/stashbot/webpanel/RetriggerLinkWebPanel.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 
 import com.atlassian.plugin.web.model.WebPanel;
-import com.atlassian.stash.content.Changeset;
+import com.atlassian.stash.commit.Commit;
 import com.atlassian.stash.repository.Repository;
 import com.palantir.stash.stashbot.config.ConfigurationPersistenceService;
 import com.palantir.stash.stashbot.jobtemplate.JobType;
@@ -68,11 +68,11 @@ public class RetriggerLinkWebPanel implements WebPanel {
                 return;
             }
 
-            Changeset changeset = (Changeset) context.get("changeset");
+            Commit Commit = (Commit) context.get("changeset");
             String url = ub.getJenkinsTriggerUrl(repo, JobType.VERIFY_COMMIT,
-                changeset.getId(), null);
+                Commit.getId(), null);
             String pubUrl = ub.getJenkinsTriggerUrl(repo, JobType.PUBLISH,
-                changeset.getId(), null);
+                Commit.getId(), null);
             // TODO: add ?reason=<buildRef> somehow to end of URLs?
             writer.append("Trigger: ( <a href=\"" + url + "\">Verify</a> | ");
             writer.append("<a href=\"" + pubUrl + "\">Publish</a> )");

--- a/src/main/java/com/palantir/stash/stashbot/webpanel/RetriggerLinkWebPanel.java
+++ b/src/main/java/com/palantir/stash/stashbot/webpanel/RetriggerLinkWebPanel.java
@@ -68,7 +68,7 @@ public class RetriggerLinkWebPanel implements WebPanel {
                 return;
             }
 
-            Commit Commit = (Commit) context.get("changeset");
+            Commit Commit = (Commit) context.get("commit");
             String url = ub.getJenkinsTriggerUrl(repo, JobType.VERIFY_COMMIT,
                 Commit.getId(), null);
             String pubUrl = ub.getJenkinsTriggerUrl(repo, JobType.PUBLISH,

--- a/src/test/java/com/palantir/stash/stashbot/config/ConfigurationTest.java
+++ b/src/test/java/com/palantir/stash/stashbot/config/ConfigurationTest.java
@@ -87,8 +87,8 @@ public class ConfigurationTest {
         Mockito.when(pr.getFromRef()).thenReturn(fromRef);
         Mockito.when(pr.getId()).thenReturn(PR_ID);
         Mockito.when(toRef.getRepository()).thenReturn(repo);
-        Mockito.when(toRef.getLatestChangeset()).thenReturn(TO_SHA);
-        Mockito.when(fromRef.getLatestChangeset()).thenReturn(FROM_SHA);
+        Mockito.when(toRef.getLatestCommit()).thenReturn(TO_SHA);
+        Mockito.when(fromRef.getLatestCommit()).thenReturn(FROM_SHA);
         Mockito.when(repo.getId()).thenReturn(REPO_ID);
 
         // ensure our runner sets this for us

--- a/src/test/java/com/palantir/stash/stashbot/hooks/PullRequestBuildSuccessMergeCheckTest.java
+++ b/src/test/java/com/palantir/stash/stashbot/hooks/PullRequestBuildSuccessMergeCheckTest.java
@@ -25,8 +25,8 @@ import org.mockito.MockitoAnnotations;
 import com.atlassian.stash.build.BuildStats;
 import com.atlassian.stash.build.BuildStatusService;
 import com.atlassian.stash.commit.CommitService;
-import com.atlassian.stash.content.Changeset;
-import com.atlassian.stash.content.ChangesetsBetweenRequest;
+import com.atlassian.stash.commit.Commit;
+import com.atlassian.stash.commit.CommitsBetweenRequest;
 import com.atlassian.stash.pull.PullRequest;
 import com.atlassian.stash.pull.PullRequestRef;
 import com.atlassian.stash.repository.Repository;
@@ -78,18 +78,18 @@ public class PullRequestBuildSuccessMergeCheckTest {
     @Mock
     private PullRequestMetadata prm2;
     @Mock
-    private Page<Changeset> mockPage;
+    private Page<Commit> mockPage;
     @Mock
-    private Changeset changeA;
+    private Commit changeA;
     @Mock
-    private Changeset changeB;
+    private Commit changeB;
     @Mock
     private BuildStats bsA;
     @Mock
     private BuildStats bsB;
 
     private final PluginLoggerFactory lf = new PluginLoggerFactory();
-    private List<Changeset> changesets;
+    private List<Commit> commits;
 
     @Before
     public void setUp() throws SQLException {
@@ -111,10 +111,10 @@ public class PullRequestBuildSuccessMergeCheckTest {
         Mockito.when(pr.getToRef()).thenReturn(toRef);
 
         Mockito.when(fromRef.getRepository()).thenReturn(repo);
-        Mockito.when(fromRef.getLatestChangeset()).thenReturn(TO_SHA);
+        Mockito.when(fromRef.getLatestCommit()).thenReturn(TO_SHA);
         Mockito.when(toRef.getRepository()).thenReturn(repo);
         Mockito.when(toRef.getId()).thenReturn(TO_SHA);
-        Mockito.when(toRef.getLatestChangeset()).thenReturn(TO_SHA);
+        Mockito.when(toRef.getLatestCommit()).thenReturn(TO_SHA);
 
         Mockito.when(cpm.getPullRequestMetadata(pr)).thenReturn(prm);
         Mockito.when(cpm.getPullRequestMetadataWithoutToRef(pr)).thenReturn(ImmutableList.of(prm, prm2));
@@ -125,11 +125,11 @@ public class PullRequestBuildSuccessMergeCheckTest {
         Mockito.when(prm2.getToSha()).thenReturn(TO_SHA2);
         Mockito.when(prm2.getFromSha()).thenReturn(FROM_SHA);
 
-        changesets = ImmutableList.of(changeA, changeB);
+        commits = ImmutableList.of(changeA, changeB);
         Mockito.when(
-            cs.getChangesetsBetween(Mockito.any(ChangesetsBetweenRequest.class), Mockito.any(PageRequest.class)))
+            cs.getCommitsBetween(Mockito.any(CommitsBetweenRequest.class), Mockito.any(PageRequest.class)))
             .thenReturn(mockPage);
-        Mockito.when(mockPage.getValues()).thenReturn(changesets);
+        Mockito.when(mockPage.getValues()).thenReturn(commits);
         Mockito.when(mockPage.getIsLastPage()).thenReturn(true);
         Mockito.when(changeA.getId()).thenReturn(SHA_A);
         Mockito.when(changeB.getId()).thenReturn(SHA_B);
@@ -185,7 +185,7 @@ public class PullRequestBuildSuccessMergeCheckTest {
 
     @Test
     public void testSuccessMergeCheckWhenPartialMatchTest() {
-        Mockito.when(toRef.getLatestChangeset()).thenReturn(TO_SHA2); // instead of TO_SHA
+        Mockito.when(toRef.getLatestCommit()).thenReturn(TO_SHA2); // instead of TO_SHA
         // returns only prm2, not prm (so no success)
         Mockito.when(cpm.getPullRequestMetadataWithoutToRef(pr)).thenReturn(ImmutableList.of(prm2));
         Mockito.when(rc.getRebuildOnTargetUpdate()).thenReturn(false);
@@ -202,7 +202,7 @@ public class PullRequestBuildSuccessMergeCheckTest {
 
     @Test
     public void testFailsMergeCheckWhenPartialMatchTest() {
-        Mockito.when(toRef.getLatestChangeset()).thenReturn(TO_SHA2); // instead of TO_SHA
+        Mockito.when(toRef.getLatestCommit()).thenReturn(TO_SHA2); // instead of TO_SHA
         Mockito.when(rc.getRebuildOnTargetUpdate()).thenReturn(false);
 
         // neither exact match nor inexact match have success

--- a/src/test/java/com/palantir/stash/stashbot/hooks/PullRequestListenerTest.java
+++ b/src/test/java/com/palantir/stash/stashbot/hooks/PullRequestListenerTest.java
@@ -96,10 +96,10 @@ public class PullRequestListenerTest {
 
         Mockito.when(fromRef.getRepository()).thenReturn(repo);
         Mockito.when(fromRef.getId()).thenReturn(HEAD_BR);
-        Mockito.when(fromRef.getLatestChangeset()).thenReturn(HEAD);
+        Mockito.when(fromRef.getLatestCommit()).thenReturn(HEAD);
         Mockito.when(toRef.getRepository()).thenReturn(repo);
         Mockito.when(toRef.getId()).thenReturn(MERGE_BR);
-        Mockito.when(toRef.getLatestChangeset()).thenReturn(MERGE_HEAD);
+        Mockito.when(toRef.getLatestCommit()).thenReturn(MERGE_HEAD);
 
         Mockito.when(prm.getPullRequestId()).thenReturn(PULL_REQUEST_ID);
         Mockito.when(prm.getToSha()).thenReturn(MERGE_HEAD);
@@ -220,7 +220,7 @@ public class PullRequestListenerTest {
         Mockito.when(prm.getBuildStarted()).thenReturn(true);
         Mockito.when(prm2.getBuildStarted()).thenReturn(true);
         Mockito.when(prm2.getToSha()).thenReturn("different value");
-        Mockito.when(toRef.getLatestChangeset()).thenReturn("different value");
+        Mockito.when(toRef.getLatestCommit()).thenReturn("different value");
         Mockito.when(cpm.getPullRequestMetadata(pr)).thenReturn(prm);
         Mockito.when(cpm.getPullRequestMetadataWithoutToRef(pr)).thenReturn(ImmutableList.of(prm, prm2));
         Mockito.when(rc.getRebuildOnTargetUpdate()).thenReturn(false);

--- a/src/test/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHookTest.java
+++ b/src/test/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHookTest.java
@@ -101,7 +101,7 @@ public class TriggerJenkinsBuildHookTest {
 
         // MGC stuff
         mgc = new MockGitCommandBuilderFactory();
-        mgc.getChangesets().add(HEAD);
+        mgc.getCommits().add(HEAD);
         mgc.getBranchMap().put(HEAD, ImmutableList.of("  otherbranch"));
 
         gcbf = mgc.getGitCommandBuilderFactory();
@@ -137,7 +137,7 @@ public class TriggerJenkinsBuildHookTest {
     @Test
     public void testNoBuildOnDelete() {
         Mockito.when(change.getType()).thenReturn(RefChangeType.DELETE);
-        mgc.getChangesets().clear(); // empty changesets means no new changes
+        mgc.getCommits().clear(); // empty Commits means no new changes
 
         tjbh.onReceive(repo, changes, hr);
 
@@ -175,9 +175,9 @@ public class TriggerJenkinsBuildHookTest {
 
     @Test
     public void testVerifyBuildsMultipleChanges() {
-        mgc.getChangesets().clear();
-        mgc.getChangesets().add(HEAD_MINUS_ONE);
-        mgc.getChangesets().add(HEAD);
+        mgc.getCommits().clear();
+        mgc.getCommits().add(HEAD_MINUS_ONE);
+        mgc.getCommits().add(HEAD);
 
         tjbh.onReceive(repo, changes, hr);
 
@@ -192,11 +192,11 @@ public class TriggerJenkinsBuildHookTest {
     @Test
     public void testVerifyIgnoresChangeAlreadyInPreviousBranch() {
         // the revlist call here is -- HEAD ^HEAD_MINUS_ONE
-        // so we'll accomplish that by adding both to the changesets list but blacklisting HEAD_MINUS_ONE so the only new change is HEAD.
-        mgc.getChangesets().clear();
-        mgc.getChangesets().add(HEAD_MINUS_ONE);
-        mgc.getChangesets().add(HEAD);
-        mgc.getBlacklistedChangesets().add(HEAD_MINUS_ONE);
+        // so we'll accomplish that by adding both to the Commits list but blacklisting HEAD_MINUS_ONE so the only new change is HEAD.
+        mgc.getCommits().clear();
+        mgc.getCommits().add(HEAD_MINUS_ONE);
+        mgc.getCommits().add(HEAD);
+        mgc.getBlacklistedCommits().add(HEAD_MINUS_ONE);
         // HEAD_MINUS_ONE is already in branch master2, so don't verify it
         mgc.getBranchMap().put(HEAD_MINUS_ONE, ImmutableList.of("  master2"));
 
@@ -209,9 +209,9 @@ public class TriggerJenkinsBuildHookTest {
 
     @Test
     public void testVerifyNewBranch() {
-        mgc.getChangesets().clear();
-        mgc.getChangesets().add(HEAD_MINUS_ONE);
-        mgc.getChangesets().add(HEAD);
+        mgc.getCommits().clear();
+        mgc.getCommits().add(HEAD_MINUS_ONE);
+        mgc.getCommits().add(HEAD);
         Mockito.when(change.getType()).thenReturn(RefChangeType.ADD);
         Mockito.when(change.getFromHash()).thenReturn("0000000000000000000000000000000000000000");
 

--- a/src/test/java/com/palantir/stash/stashbot/mocks/MockGitCommandBuilderFactory.java
+++ b/src/test/java/com/palantir/stash/stashbot/mocks/MockGitCommandBuilderFactory.java
@@ -45,8 +45,8 @@ public class MockGitCommandBuilderFactory {
     private GitScmCommandBuilder branchCommandBuilder;
     private GitCommand<Object> branchCommand;
 
-    private List<String> changesets;
-    private Set<String> blacklistedChangesets;
+    private List<String> commits;
+    private Set<String> blacklistedCommits;
     private Map<String, List<String>> branchMap;
 
     public MockGitCommandBuilderFactory() {
@@ -55,9 +55,9 @@ public class MockGitCommandBuilderFactory {
 
     @SuppressWarnings("unchecked")
     private void reset() {
-        // list of changesets in order
-        changesets = new ArrayList<String>();
-        blacklistedChangesets = new HashSet<String>();
+        // list of commits in order
+        commits = new ArrayList<String>();
+        blacklistedCommits = new HashSet<String>();
         // for each hash, list of branches that contain said hash
         branchMap = new HashMap<String, List<String>>();
 
@@ -83,8 +83,8 @@ public class MockGitCommandBuilderFactory {
                 CommandOutputHandler<Object> coh = cohCaptor.getValue();
 
                 List<String> finalCS = new ArrayList<String>();
-                for (String cs : changesets) {
-                    if (!blacklistedChangesets.contains(cs)) {
+                for (String cs : commits) {
+                    if (!blacklistedCommits.contains(cs)) {
                         finalCS.add(cs);
                     }
                 }
@@ -119,12 +119,12 @@ public class MockGitCommandBuilderFactory {
         }).when(branchCommand).call();
     }
 
-    public List<String> getChangesets() {
-        return changesets;
+    public List<String> getCommits() {
+        return commits;
     }
 
-    public Set<String> getBlacklistedChangesets() {
-        return blacklistedChangesets;
+    public Set<String> getBlacklistedCommits() {
+        return blacklistedCommits;
     }
 
     public Map<String, List<String>> getBranchMap() {

--- a/src/test/java/com/palantir/stash/stashbot/mocks/MockJobTemplateFactory.java
+++ b/src/test/java/com/palantir/stash/stashbot/mocks/MockJobTemplateFactory.java
@@ -64,10 +64,11 @@ public class MockJobTemplateFactory {
         Mockito.when(jm.isVisible()).thenReturn(true);
         Mockito.when(jm.isEnabled()).thenReturn(true);
 
+        templates.add(template);
+
         Mockito.when(jtm.getJenkinsJobsForRepository(rc)).thenReturn(ImmutableList.copyOf(templates));
         Mockito.when(jtm.fromString(rc, jt.toString())).thenReturn(template);
 
-        templates.add(template);
         mappings.add(jm);
         return template;
     }

--- a/src/test/java/com/palantir/stash/stashbot/urlbuilder/StashbotUrlBuilderTest.java
+++ b/src/test/java/com/palantir/stash/stashbot/urlbuilder/StashbotUrlBuilderTest.java
@@ -77,8 +77,8 @@ public class StashbotUrlBuilderTest {
         Mockito.when(pr.getId()).thenReturn(PULL_REQUEST_ID);
         Mockito.when(pr.getFromRef()).thenReturn(fromRef);
         Mockito.when(pr.getToRef()).thenReturn(toRef);
-        Mockito.when(toRef.getLatestChangeset()).thenReturn(TO_SHA);
-        Mockito.when(fromRef.getLatestChangeset()).thenReturn(BUILD_HEAD);
+        Mockito.when(toRef.getLatestCommit()).thenReturn(TO_SHA);
+        Mockito.when(fromRef.getLatestCommit()).thenReturn(BUILD_HEAD);
         Mockito.when(repo.getId()).thenReturn(REPO_ID);
         Mockito.when(rs.getCloneLinks(Mockito.any(RepositoryCloneLinksRequest.class))).thenReturn(links);
 


### PR DESCRIPTION
This fixes a few issues in upgrading to stash 3.11.  However, there are some things that have me puzzled too: (1) How did the tests ever work with stash < 3.8?!?  It seems like the fix in commit 2e9ecee (Fix simple order of operations logic bug) should have been required to get the tests to work with any version of stash.  The fact that the tests did pass even with that bug is troubling (and confusing).  (2) Is commit 7e71b39 (squash! Update due to Stash renaming Changeset -> Commit in APIs) actually correct?  I couldn't find anywhere that '"changeset"' was otherwise used as a quoted string making me wonder how it all worked (some nifty reflection or something)?  The tests pass with or without that change, but I suspect that something not tested by the current tests depends on getting that value right.
