### PR TITLE
git clean with sudo where possible

### DIFF
--- a/src/main/resources/jenkins-verify-pull-request-job.vm
+++ b/src/main/resources/jenkins-verify-pull-request-job.vm
@@ -121,7 +121,7 @@
   <builders>
     <hudson.tasks.Shell>
         <!-- for insane, incomprehensible reasons, jenkins does not do this automatically -->
-        <command>(git reset --hard HEAD &amp;&amp; git clean -fdx) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)</command>
+        <command>(git reset --hard HEAD &amp;&amp; (sudo -n git clean -fdx || git clean -fdx)) || (echo "SETUP exited with status $? ; FAILURE1" ; /bin/false)</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
         <command>$esc.xml($startedCommand)</command>


### PR DESCRIPTION
Depending on whether the building user has sudo privileges, it's possible to write files in a build that Jenkins can't clean up, breaking builds for everyone else on that node. Stashbot sudo cleaning would avoid this.